### PR TITLE
Reduce Docker image size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project are documented in this file.
 - Print possible commands when an invalid command is used.
 - Documentation examples.
 - Documentation for extending `bmcmanager` with new features.
+- Reduced Docker image size.
 
 ### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,5 @@ RUN apt-get update && \
         freeipmi && \
     rm -rf /var/lib/apt/lists && \
     pip install --no-cache-dir ${REPO}@${BRANCH} && \
-    apt-get purge git -y
+    apt-get purge git -y && \
+    apt-get autoremove -y


### PR DESCRIPTION
### Changes

- Do `apt-get autoremove` as a last step during image build.

This reduces the image size by ~ 50MB

```
test                         latest              5aa95b0a81d7        5 seconds ago       243MB
test2                        latest              0f1cf87b6880        3 minutes ago       193MB
```