### PR TITLE
Show error message when no DCIM is configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project are documented in this file.
 
 - Improved log message levels so that no sensitive data is printed unless debugging.
 - Command-line arguments handling.
+- Show a helpful error message when no DCIM has been configured.
 
 
 ## [v0.2] (2020-07-05)

--- a/bmcmanager/commands/base.py
+++ b/bmcmanager/commands/base.py
@@ -29,6 +29,8 @@ from bmcmanager.errors import BMCManagerError
 from bmcmanager.logs import log
 from bmcmanager import exitcode
 
+README = 'https://github.com/grnet/BMCManager/blob/master/README.md'
+
 
 def int_in_range_argument(itt):
     """
@@ -91,6 +93,12 @@ def get_dcim(args, config):
     """
     Get a configured DCIM from arguments and configuration
     """
+    if args.dcim not in DCIMS:
+        raise RuntimeError(
+            'Unsupported DCIM "{}", see {}'.format(args.dcim, README))
+    if args.dcim not in config:
+        raise RuntimeError(
+            'No configuration for DCIM "{}", see {}'.format(args.dcim, README))
     return DCIMS[args.dcim](args, config[args.dcim])
 
 


### PR DESCRIPTION
### Changes

- Show a helpful error message when requested DCIM is not supported or configured, and point to README.md for more information.

