### PR TITLE
Recover from expired session errors when connecting to the web interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ All notable changes to this project are documented in this file.
 
 - Improved log message levels so that no sensitive data is printed unless debugging.
 - Command-line arguments handling.
+- Try to recover from expired session errors.
 
 
 ## [v0.2] (2020-07-05)


### PR DESCRIPTION
### Changes

- Expired session errors when doing initial connection to the web interface are retryable. Try 5 times with back-off before returning an error. 