### PR TITLE
Fixed bug: Compare firmware versions as tuples instead of strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project are documented in this file.
 
 ### Fixed
 
+- Compare versions as tuples instead of strings if possible when checking for firmware upgrades.
 
 ## [v1.0] (2020-07-09)
 


### PR DESCRIPTION
This fixes bmcmanager being unable to upgrade in situations where the newer version (as an alphanumeric) is less than the older version. e.g. ("5.11" < "5.2") which does not make sense, because 11 > 2

The proposed change converts the version string into a tuple before comparing. So `(5, 11) > (5, 2)`. If the conversion fails for whatever reason (e.g. version is not `major.minor[.patchlevel]`, then alphanumeric order is used as fallback, preserving the existing  behaviour.