### PR TITLE
Fix success return code on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project are documented in this file.
 
 ### Fixed
 
+- When a command failed, sometimes a successful return code (0) was returned, along with a false "No servers found" message.
+
 
 ## [v1.0.1] (2020-09-07)
 

--- a/bmcmanager/commands/base.py
+++ b/bmcmanager/commands/base.py
@@ -138,7 +138,8 @@ def bmcmanager_take_action(cmd, parsed_args):
     cmd.config = get_config(parsed_args.config_file)
     dcim = get_dcim(parsed_args, cmd.config)
 
-    for oob_info in dcim.get_oobs():
+    idx = None
+    for idx, oob_info in enumerate(dcim.get_oobs()):
         oob_config = get_oob_config(cmd.config, dcim, oob_info)
         log.debug('Creating OOB object for {}'.format(oob_info['oob']))
         try:
@@ -153,7 +154,8 @@ def bmcmanager_take_action(cmd, parsed_args):
                 return cmd.action(oob)
         except Exception as e:
             log.exception('Unhandled exception: {}'.format(e))
-    else:
+
+    if idx is None:
         log.fatal('No servers found for "{}"'.format(parsed_args.server))
         return [], []
 


### PR DESCRIPTION
There was a bug where if BMCManager failed under specific conditions, the return code was actually 0 and a false "No servers found" message was printed.

This is because of a corner case breaking the expected `for-else` flow. This change drops `for-else` completely.