### PR TITLE
Add `ipmi` field in `bmcmanager server list` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project are documented in this file.
 
 ### Added
 
+- `bmcmanager server list` now also prints the server IPMI addresses.
+
 ### Changed
 
 ### Fixed

--- a/bmcmanager/commands/server/list.py
+++ b/bmcmanager/commands/server/list.py
@@ -22,10 +22,19 @@ class List(BMCManagerServerListCommand):
     print list of available servers
     """
     columns = [
-        'id', 'name', 'site', 'serial', 'manufacturer', 'device_type', 'status']
+        'id',
+        'name',
+        'site',
+        'serial',
+        'manufacturer',
+        'device_type',
+        'status',
+        'ipmi',
+    ]
 
     def take_action(self, parsed_args):
         dcim = get_dcim(parsed_args, get_config(parsed_args.config_file))
-        values = [[o['info'][col] for col in self.columns] for o in dcim.get_oobs()]
+        values = [[o['info'][col]
+                   for col in self.columns] for o in dcim.get_oobs()]
 
         return self.columns, values


### PR DESCRIPTION
#### Summary

Add `ipmi` field in `bmcmanager server list` command

#### Why Is This Needed

Makes it easier to lookup IPMI addresses from NetBox