### PR TITLE
Set supported snapcraft architectures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project are documented in this file.
 ### Changed
 
 - Switched to `pbr` for installation.
+- Build snap for `amd64` and `arm64` architectures.
 
 ### Fixed
 

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -6,6 +6,9 @@ base: core18
 confinement: strict
 grade: stable
 license: GPL-3.0
+architectures:
+  - build-on: amd64
+  - build-on: arm64
 
 parts:
   bmcmanager:


### PR DESCRIPTION
#### Summary

Add list of supported architectures for the bmcmanager snap (`amd64` and `arm64`). This is useful, so that snapcraft builds only attempt to build and release for those architectures, since the others are currently failing.