### PR TITLE
Fix crashes when IPMI address does not have http/https schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project are documented in this file.
 
 ### Fixed
 
+- Crashes when the IPMI address was not prefixed with `http://` or `https://`.
+
 ## [v1.0.3] (2020-10-28)
 
 ### Added

--- a/bmcmanager/oob/base.py
+++ b/bmcmanager/oob/base.py
@@ -76,8 +76,15 @@ class OobBase(object):
             raise OobError('Could not open browser {}'.format(
                 ' '.join(command)))
 
+    def _get_http_ipmi_host(self):
+        ipmi_host = self.oob_info['ipmi']
+        if not ipmi_host.startswith('http'):
+            ipmi_host = 'https://{}'.format(ipmi_host)
+
+        return ipmi_host
+
     def open(self):
-        self._execute_popen([BROWSER_OPEN, self.oob_info['ipmi']])
+        self._execute_popen([BROWSER_OPEN, self._get_http_ipmi_host()])
 
     def ssh(self):
         status_command = ['chassis', 'power', 'status']

--- a/bmcmanager/oob/lenovo.py
+++ b/bmcmanager/oob/lenovo.py
@@ -105,8 +105,7 @@ class Lenovo(OobBase):
                 return [], False
 
     def _connect(self):
-        ipmi_host = self.oob_info['ipmi']
-        url = ipmi_host + self.URL_LOGIN
+        url = self._get_http_ipmi_host() + self.URL_LOGIN
 
         cookies = self._get_console_cookies()
         headers = self._get_console_headers()
@@ -148,10 +147,9 @@ class Lenovo(OobBase):
         )
 
     def console(self):
-
         self._connect()
 
-        ipmi = self.oob_info['ipmi']
+        ipmi = self._get_http_ipmi_host()
         url = ipmi + self.URL_VNC.format(ipmi.replace('https://', ''))
         answer = self._post(
             url, None, self.session_token, self.CSRF_token).text
@@ -224,7 +222,7 @@ class Lenovo(OobBase):
         if not hasattr(self, 'CSRF_token'):
             self._connect()
 
-        ipmi_host = self.oob_info['ipmi']
+        ipmi_host = self._get_http_ipmi_host()
         url = ipmi_host + '/rpc/{}.asp'.format(rpc)
         response = self._post(url, params, self.session_token, self.CSRF_token)
 


### PR DESCRIPTION
#### Summary

This fixes bmcmanager behaviour when the IPMI address, as it is retrieved from the DCIM (NetBox), is not prefixed with the `http` or `https` schema.

#### Changes

- Add a new helper function to `OobBase` that retrieves the IPMI address, adding the `https://` prefix if it is missing.
- Use that everywhere else.