### PR TITLE
Add expiremental support for MaaS

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [`bmcmanager`](https://github.com/grnet/bmcmanager.git) is a tool for performing operations on rack units. It originated as a [`rackops`](https://github.com/grnet/rackops.git) fork, but has since been re-written almost from scratch, offering lots of additional functionality, bug-fixes and all-around improvements.
 
-`bmcmanager` supports Lenovo, Dell and Fujitsu servers, and relies on [`NetBox`](https://netbox.readthedocs.io/en/stable/) for DCIM and IPAM.
+`bmcmanager` supports Lenovo, Dell and Fujitsu servers, and relies on [`NetBox`](https://netbox.readthedocs.io/en/stable/) for DCIM and IPAM. There is also expiremental support for [`MaaS`](https://maas.io).
 
 `bmcmanager` is released under the terms of the GPL-3.0 license.
 
@@ -22,6 +22,7 @@
 - Configure unique IPMI credentials per server, store them as NetBox secrets and retrieve them automatically from NetBox.
 - Bash auto-completion.
 - Supports multiple output formats supported.
+- (Expiremental) MaaS support. Match servers by hostname, and use MaaS IPMI credentials for all bmcmanager commands.
 
 ## Installation
 
@@ -96,6 +97,17 @@ netbox_token = <netbox_api_token>
 session_key = <netbox_session_key>
 ; [Optional] Timeout when connecting to NetBox (in seconds).
 timeout = 10
+
+;; Configure of "maas" DCIM. Only required if using MaaS [Expiremental].
+[maas]
+; Required. Example: https://maas.internal.deployment:5240/MAAS/api/2.0
+api_url = <maas_api_url>
+; Required. Generate from MaaS GUI > User > API Keys > Generate MAAS API key.
+; Example: AAAAAAAAAAA:BBBBBBBBBBBBBBB:CCCCCCCCCCCCCCCCC
+api_key = <maas_api_key>
+; Required for `bmcmanager open dcim` command. This is the root MaaS GUI URL.
+; Example: https://maas.internal.deployment/
+ui_url = <maas_ui_url>
 
 ;; Configuration of "lenovo" OOB
 [lenovo]

--- a/README.md
+++ b/README.md
@@ -206,6 +206,11 @@ Some configuration can be overriden using environment variables:
   $ bmcmanager ipmi credentials get lar0510
   ```
 
+- Activate SOL for a MaaS host:
+  ```bash
+  $ bmcmanager ipmi tool --dcim maas HOSTNAME sol activate
+  ```
+
 ## Usage
 
 Use `bmcmanager --help` for a list of available commands. Common command-line arguments for all supported commands are:

--- a/bmcmanager/commands/base.py
+++ b/bmcmanager/commands/base.py
@@ -78,7 +78,7 @@ def server_arguments(parser):
     parser.add_argument(
         '-d', '--dcim',
         help='name of DCIM to use',
-        choices=['netbox'],
+        choices=['netbox', 'maas'],
         default='netbox',
     )
     parser.add_argument(

--- a/bmcmanager/dcim/__init__.py
+++ b/bmcmanager/dcim/__init__.py
@@ -14,7 +14,9 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from bmcmanager.dcim.netbox import Netbox
+from bmcmanager.dcim.maas import MaaS
 
 DCIMS = {
-    'netbox': Netbox
+    'netbox': Netbox,
+    'maas': MaaS,
 }

--- a/bmcmanager/dcim/maas.py
+++ b/bmcmanager/dcim/maas.py
@@ -1,0 +1,87 @@
+# Copyright (C) 2020  GRNET S.A.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from maas.client.bones import SessionAPI
+
+from bmcmanager.logs import log
+from bmcmanager.dcim.base import DcimBase, DcimError
+
+
+class MaaS(DcimBase):
+    def __init__(self, args, config):
+        super(MaaS, self).__init__(args, config)
+        self._session = None
+
+        if not self.dcim_params['api_url']:
+            raise DcimError('MaaS API URL is not set, see README.md')
+        if not self.dcim_params['api_key']:
+            raise DcimError('MaaS API Key is not set, see README.md')
+
+        self.api_url = self.dcim_params['api_url']
+        self.api_key = self.dcim_params['api_key']
+
+    def session(self) -> SessionAPI:
+        """
+        Return a sessions to the MaaS server. Subsequent calls reuse the same
+        connection
+        """
+        if self._session:
+            return self._session
+
+        log.info(f'Connecting to {self.api_url}')
+        _, self._session = SessionAPI.connect(self.api_url, apikey=self.api_key)
+
+        return self._session
+
+    def get_oobs(self):
+        for machine in self.session().Machines.read(hostname=[self.identifier]):
+            power = self.session().Machine.power_parameters(system_id=machine['system_id'])
+            yield {
+                'asset_tag': '',
+                'ipmi': power['power_address'],
+                'oob': machine['hardware_info']['mainboard_vendor'].lower(),
+                'info': {
+                    'id': machine['system_id'],
+                    'name': machine['hostname'],
+                    'display_name': machine['hostname'],
+                    'serial': machine['hardware_info']['system_serial'],
+                    'ipmi': power['power_address'],
+                    'manufacturer': machine['hardware_info']['mainboard_vendor'],
+                    'device_type': machine['hardware_info']['mainboard_product'],
+                    'bios': machine['owner_data'].get('BIOS', ''),
+                    'tsm': machine['owner_data'].get('TSM', ''),
+                    'psu': machine['owner_data'].get('PSU', ''),
+                    'site': machine['domain']['name'],
+                    'status': machine['status_name'],
+                },
+                'identifier': machine['hostname'],
+                'custom_fields': machine['owner_data'],
+            }
+
+    def get_secret(self, role, oob_info):
+        power = self.session().Machine.power_parameters(system_id=oob_info['info']['id'])
+        return {
+            'name': power['power_user'],
+            'plaintext': power['power_pass'],
+        }
+
+    def set_custom_fields(self, oob_info, custom_fields):
+        raise DcimError('not support by MaaS DCIM')
+
+    def oob_url(self, oob_info):
+        if not self.dcim_params.get('ui_url'):
+            raise DcimError('MaaS UI URL is not set, see README.md')
+        return '{}/MAAS/l/machine/{}'.format(
+            self.dcim_params['ui_url'], oob_info['info']['id'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ beautifulsoup4==4.9.3
 paramiko==2.7.1
 requests==2.24.0
 cliff==3.4.0
+python-libmaas==0.6.6


### PR DESCRIPTION
#### Summary

Expiremental support using MaaS as DCIM instead of NetBox.

#### Changes

- Add a new DCIM `MaaS`, extending `DcimBase`.
- Implement `get_oobs` (machine retrieval), and `get_secret` (for retrieving IPMI credentials). 
- Add documentation, noting that this is expiremental for now.