### PR TITLE
Fix nagios result code when ipmi command timed out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project are documented in this file.
 ### Fixed
 
 - Crashes when the IPMI address was not prefixed with `http://` or `https://`.
+- `bmcmanager check sensor` command returned OK status when the underlying commands timed out.
 
 ## [v1.0.3] (2020-10-28)
 

--- a/bmcmanager/oob/base.py
+++ b/bmcmanager/oob/base.py
@@ -361,7 +361,12 @@ class OobBase(object):
 
         perfdata = []
         cmd = self._ipmi_dcmi_cmd(host, self.username, self.password)
-        dcmi_output = self._execute_cmd(cmd, output=True)
+        try:
+            dcmi_output = self._execute_cmd(cmd, output=True)
+        except OobError:
+            nagios.result(nagios.UNKNOWN, 'ipmi-dcmi failed', pre=pre)
+            return
+
         match = re.findall(r'Current Power\s*:\s*(\d+)', dcmi_output)
         if match:
             perfdata.append("'Current Power'={}".format(match[0]))
@@ -369,7 +374,12 @@ class OobBase(object):
         sel_errors = list(self._get_sel_errors(host))
 
         cmd = self._ipmi_sensors_cmd(host, self.username, self.password)
-        sensors = self._execute_cmd(cmd, output=True)
+        try:
+            sensors = self._execute_cmd(cmd, output=True)
+        except OobError:
+            nagios.result(nagios.UNKNOWN, 'ipmi-sensors failed', pre=pre)
+            return
+
         sensor_warnings = []
         sensor_errors = []
         for line in sensors.split('\n')[1:-1]:


### PR DESCRIPTION
#### Summary

Fixed a bug where a command timeout would raise an exception without setting the Nagios result code to error, thus returning success.