### PR TITLE
ipmitool: Add cipher suite 17 as default

### DIFF
--- a/bmcmanager/oob/base.py
+++ b/bmcmanager/oob/base.py
@@ -127,6 +127,7 @@ class OobBase(object):
             "lanplus",
             "-H",
             host,
+            "-C 17",
         ]
 
     # command is an array


### PR DESCRIPTION
Sets ipmitool's cipher suite to 17.

After upgrading Lenovo's TSM firmware to latest on our RD350 servers we saw that the default crypto algorithm used by ipmitool to communicate with IPMI, is not supported anymore.
By manualy selecting the 17th algorithm communication is enstablished. This issue is fixed in newer ipmitool versions, but are not yet introduced for Debian buster/bullseye variants.