### PR TITLE
Replace display_name for netbox v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,14 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+## [v1.3.0] (2023-09-04)
+
 ### Added
 
 ### Changed
+
+- Changed 'display_name' field to 'display' since 'display_name' field
+  has been removed in Netbox 2.11.0
 
 ### Fixed
 

--- a/bmcmanager/commands/base.py
+++ b/bmcmanager/commands/base.py
@@ -118,6 +118,7 @@ def get_oob_config(config, dcim, oob_info, get_secret=True):
             cfg["username"] = secret["name"]
         if secret["plaintext"]:
             cfg["password"] = secret["plaintext"]
+    print(cfg["username"], cfg["password"], oob_params, oob_info)
 
     cfg["username"] = os.getenv("BMCMANAGER_USERNAME", cfg["username"])
     cfg["password"] = os.getenv("BMCMANAGER_PASSWORD", cfg["password"])

--- a/bmcmanager/commands/base.py
+++ b/bmcmanager/commands/base.py
@@ -118,7 +118,6 @@ def get_oob_config(config, dcim, oob_info, get_secret=True):
             cfg["username"] = secret["name"]
         if secret["plaintext"]:
             cfg["password"] = secret["plaintext"]
-    print(cfg["username"], cfg["password"], oob_params, oob_info)
 
     cfg["username"] = os.getenv("BMCMANAGER_USERNAME", cfg["username"])
     cfg["password"] = os.getenv("BMCMANAGER_PASSWORD", cfg["password"])

--- a/bmcmanager/dcim/netbox.py
+++ b/bmcmanager/dcim/netbox.py
@@ -117,7 +117,7 @@ class Netbox(DcimBase):
         return {
             "id": result["id"],
             "name": result["name"],
-            "display_name": result["display_name"],
+            "display": result["display"],
             "serial": result["serial"],
             "ipmi": result["custom_fields"]["IPMI"] or "unknown-address",
             "manufacturer": result["device_type"]["manufacturer"]["slug"],


### PR DESCRIPTION
In Netbox v3.0.0 the 'display_name' field has been removed.